### PR TITLE
Fixed inverted logic adjustment for the memory meter on linux.

### DIFF
--- a/linux/memmeter.cc
+++ b/linux/memmeter.cc
@@ -56,7 +56,15 @@ void MemMeter::checkevent( void ){
 
 void MemMeter::getmeminfo( void ){
   getmemstat(MEMFILENAME, _MIlineInfos, _numMIlineInfos);
+  /*
+   * Commenting out as "mapped" and "cached" seem to be unrelated.
+   * Sometimes mapped > cached, sometimes cached > mapped.
+   * Let's leave them raw.
+   *		--RAM, 2015-09-16
+   */
+#if 0	/* DISABLED */
   fields_[3] -= fields_[4]; // mapped comes from cache
+#endif
   fields_[0] = total_ - fields_[5] - fields_[4] - fields_[3] - fields_[2] - fields_[1];
 
   if (total_)

--- a/linux/memmeter.cc
+++ b/linux/memmeter.cc
@@ -109,10 +109,11 @@ void MemMeter::getstats() {
   fields_[1] = KB(buffers);
   fields_[2] = KB(slab);
   fields_[3] = KB(mapped);
-  fields_[4] = KB(cached - mapped); // cached includes mapped
+  fields_[4] = KB(cached);
   fields_[5] = KB(mem_free);
 
-  fields_[0] = KB(mem_total - mem_free - buffers - cached - slab);
+  fields_[0] =
+	KB(mem_total - mem_free - buffers - mapped - cached - slab);
   total_ =     KB(mem_total);
 
   setUsed(KB(mem_total - mem_free), KB(mem_total));

--- a/linux/memmeter.cc
+++ b/linux/memmeter.cc
@@ -56,7 +56,7 @@ void MemMeter::checkevent( void ){
 
 void MemMeter::getmeminfo( void ){
   getmemstat(MEMFILENAME, _MIlineInfos, _numMIlineInfos);
-  fields_[4] -= fields_[3]; // mapped comes from cache
+  fields_[3] -= fields_[4]; // mapped comes from cache
   fields_[0] = total_ - fields_[5] - fields_[4] - fields_[3] - fields_[2] - fields_[1];
 
   if (total_)


### PR DESCRIPTION
The comment says that "mapped comes from cached" but it was actually
substracting from field[4] (cached) the value of field[3] (mapped).
It has to be the other way round for proper display!

The symptom that led to this bug fix was the following warning message:

  meter MemMeter had a negative value of -12621901824.000000 for field 4

Once the patch is applied, the warning goes away and the display is
properly reflecting the values that can otherwise by seen via "free"
on linux.