### PR TITLE
Fix typo that was blocking compilation on gcc 6

### DIFF
--- a/linux/acpitemp.cc
+++ b/linux/acpitemp.cc
@@ -118,12 +118,12 @@ void ACPITemp::getacpitemp( void ) {
   std::ifstream high_file(_highfile);
 
   if (!temp_file) {
-    std::cerr << "Can not open file : " << temp_file << std::endl;
+    std::cerr << "Can not open file : " << _tempfile << std::endl;
     parent_->done(1);
     return;
   }
   if (!high_file) {
-    std::cerr << "Can not open file : " << high_file << std::endl;
+    std::cerr << "Can not open file : " << _highfile << std::endl;
     parent_->done(1);
     return;
   }


### PR DESCRIPTION
It looks like the intent of this code is to print the _name_ of the file in question, not the file contents (because this is an error message).

This builds on gcc 6 (which apparently became slightly more strict with the operator<< overload).  However, I do not know how to force this error condition to be absolutely sure that the file name prints.  (Chances are good that if you see this error, you are probably having a bad day anyway.)

See also the recent discussion on the [AUR package](https://aur.archlinux.org/packages/xosview/) page.
