### PR TITLE
Fix /sys/class/net traversal on recent Linux systems

### DIFF
--- a/linux/netmeter.cc
+++ b/linux/netmeter.cc
@@ -104,8 +104,7 @@ void NetMeter::getSysStats( unsigned long long &totin, unsigned long long &totou
 
   // walk through /sys/class/net/*/statistics/{r,t}x_bytes
   while ( (ent = readdir(dir)) ) {
-    if ( !strncmp(ent->d_name, ".", 1) ||
-         !strncmp(ent->d_name, "..", 2) )
+    if ( ent->d_type != DT_LNK )
       continue;
     if ( _netIface != "False" &&
          ( (!_ignored && ent->d_name != _netIface) ||


### PR DESCRIPTION
My kernel has a file `/sys/class/net/bonding_masters`.
When xosview is doing `readdir` on `/sys/class/net`, it doesn't check whether it sees a symlink or directory and tries to open `/sys/class/net/bonding_masters/statistics/rx_bytes` which fails of course.
This patch simply checks if entry under `/sys/class/net` is a symlink.
