### PR TITLE
Fix build in FreeBSD 12

### DIFF
--- a/bsd/kernel.cc
+++ b/bsd/kernel.cc
@@ -320,7 +320,18 @@ BSDGetPageStats(uint64_t *meminfo, uint64_t *pageinfo) {
 		pageinfo[1] = (uint64_t)uvm.pgswapout;
 	}
 #else  /* HAVE_UVM */
-	struct vmmeter vm;
+	struct vmmeter_fbsd {
+		u_int v_active_count;
+		u_int v_inactive_count;
+		u_int v_wire_count;
+		u_int v_cache_count;
+		u_int v_free_count;
+		u_int v_page_size;
+		u_int v_vnodepgsin;
+		u_int v_vnodepgsout;
+		u_int v_swappgsin;
+		u_int v_swappgsout;
+	} vm;
 #if defined(XOSVIEW_FREEBSD)
 	size_t size = sizeof(unsigned int);
 #define	GET_VM_STATS(name) \


### PR DESCRIPTION
vm.stats.vm.* is not paired with the fields in struct vmmeter [anymore.](https://svnweb.freebsd.org/base/head/sys/sys/vmmeter.h?r1=328134&r2=328954)

So xosview fails to build on recent FreeBSD 12 because `v_active_count`, `v_inactive_count` and `v_free_count` are now missing

Since we are not using all the fileds in vmmeter anyway, define our own structure
with the fields we are interested in.

Testing:

* Builds for {10.4,11.1}{amd64,i386}, 11.2amd64, 12i386 OK
* Run test in 11.2 OK