### PR TITLE
Fix build on arm by not including sys/io.h

### DIFF
--- a/linux/serialmeter.cc
+++ b/linux/serialmeter.cc
@@ -30,7 +30,7 @@ typedef unsigned long long u64;
 #endif
 
 #if defined(GNULIBC) || defined(__GLIBC__)
-#if !defined(__powerpc__) && !defined(__hppa__) && !defined(__mips__) && !defined(__sparc__) && !defined(__sh__) && !defined(__s390__) && !defined(__s390x__) && !defined(__m68k__) && !defined(__aarch64__)
+#if !defined(__powerpc__) && !defined(__hppa__) && !defined(__mips__) && !defined(__sparc__) && !defined(__sh__) && !defined(__s390__) && !defined(__s390x__) && !defined(__m68k__) && !defined(__aarch64__) && !defined(__arm__)
 #include <sys/io.h>
 #endif
 #if !defined(__alpha__) && !defined(__sparc__) && !defined(__powerpc__) && !defined(__ia64__) && !defined(__hppa__) && !defined(__arm__) && !defined(__mips__) && !defined(__sh__) && !defined(__s390__) && !defined (__s390x__) && !defined(__m68k__) && !defined(__aarch64__)


### PR DESCRIPTION
It was removed in glibc-2.30:

https://sourceware.org/ml/libc-alpha/2019-08/msg00029.html
* On 32-bit Arm, support for the port-based I/O emulation and the <sys/io.h>
  header have been removed.