### PR TITLE
On NetBSD, turn cpu speed error into a warning

### DIFF
--- a/bsd/kernel.cc
+++ b/bsd/kernel.cc
@@ -278,7 +278,7 @@ BSDGetCPUSpeed() {
 	size = sizeof(speed);
 #if defined(XOSVIEW_NETBSD)
 	if ( sysctlbyname("machdep.tsc_freq", &speed, &size, NULL, 0) < 0 )
-		err(EX_OSERR, "sysctl machdep.tsc_freq failed");
+		warn("sysctl machdep.tsc_freq failed");
 #else  /* XOSVIEW_DFBSD */
 	if ( sysctlbyname("hw.tsc_frequency", &speed, &size, NULL, 0) < 0 )
 		err(EX_OSERR, "sysctl hw.tsc_frequency failed");


### PR DESCRIPTION
Different architectures use different values for this sysctl, this is why it is marked as "machdep". Not having the CPU frequency available should not be a fatal error.

**Question for you:** does it make sense to return a single value for the CPU speed? I noticed that the FreeBSD code averages the speed over all cores. NetBSD/evbarm, where I ran into this issue, can set the CPU speed independently for "big" and "little" cores, depending on CPU. I feel like it makes sense to have the frequency be a per-CPU property.

Where is the CPU speed even shown in the UI?