### PR TITLE
Fix build regression on ia64

### DIFF
--- a/linux/serialmeter.cc
+++ b/linux/serialmeter.cc
@@ -23,7 +23,7 @@
  * To fetch status information requires ioperm() and inb()
  * otherwise these meter is largely a no-op.
  */
-#if defined(__i386__) || defined(__ia64__) || defined(__amd64__)
+#if defined(__i386__) || defined(__amd64__)
 #include <sys/io.h>
 #include <sys/perm.h>
 #define HAVE_IOPERM


### PR DESCRIPTION
In b48dd68, the exclusion list of architectures for ioperm() was
inverted resulting in ia64 accidentally being added as a supported
architecture. However, the ioperm() is not available on ia64 which
causes xosview failing to build on this architecture, thus remove
ia64 from the list of supported architectures.