### PR TITLE
Update MeterMaker.cc -- count always CPU cores

### DIFF
--- a/linux/MeterMaker.cc
+++ b/linux/MeterMaker.cc
@@ -189,14 +189,18 @@ void MeterMaker::makeMeters(void){
       do {
         if (pkgCount > 1)
           snprintf(name, 8, "CPU%d", pkg);
-        push(new CoreTemp(_xos, name, caption, pkg, -1));
+	coreCount = CoreTemp::countCores(pkg);
+        if (coreCount > 0)
+	  push(new CoreTemp(_xos, name, caption, pkg, -1));
       } while (++pkg < pkgCount);
     }
     else if ( strncmp(displayType, "maximum", 1) == 0 ) {
       do {
         if (pkgCount > 1)
           snprintf(name, 8, "CPU%d", pkg);
-        push(new CoreTemp(_xos, name, caption, pkg, -2));
+        coreCount = CoreTemp::countCores(pkg);
+	if (coreCount > 0)
+	  push(new CoreTemp(_xos, name, caption, pkg, -2));
       } while (++pkg < pkgCount);
     }
     else {


### PR DESCRIPTION
I've here an INTEL cpu which shows 12 cores on pkg 0 but have a pkg 1 without any enabled cores:

find /sys/devices/platform/coretemp.*/ -name 'temp*_label' -o -type d /sys/devices/platform/coretemp.0/
/sys/devices/platform/coretemp.0/hwmon
/sys/devices/platform/coretemp.0/hwmon/hwmon3
/sys/devices/platform/coretemp.0/hwmon/hwmon3/power /sys/devices/platform/coretemp.0/hwmon/hwmon3/temp2_label /sys/devices/platform/coretemp.0/hwmon/hwmon3/temp3_label /sys/devices/platform/coretemp.0/hwmon/hwmon3/temp4_label /sys/devices/platform/coretemp.0/hwmon/hwmon3/temp5_label /sys/devices/platform/coretemp.0/hwmon/hwmon3/temp6_label /sys/devices/platform/coretemp.0/hwmon/hwmon3/temp7_label /sys/devices/platform/coretemp.0/power
/sys/devices/platform/coretemp.1/
/sys/devices/platform/coretemp.1/power

this commit avoids a SIGSEGV if average or maximum is used as coretempDisplayType